### PR TITLE
FEAT: 버튼 컴포넌트(공통) 추가 및 여러 가지 수정

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,37 +1,37 @@
 {
-  "env": {
-    "node": true,
-    "browser": true,
-    "es2021": true
-  },
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended",
-    "plugin:import/recommended",
-    "plugin:jsx-a11y/recommended",
-    "plugin:prettier/recommended"
-  ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": "latest",
-    "sourceType": "module"
-  },
-  "plugins": ["prettier"],
-  "rules": {
-    "no-unused-vars": "warn",
-    "react/react-in-jsx-scope": 0,
-    "react/jsx-uses-react": 0,
-    "prettier/prettier": "error",
-    "react/prop-types": "off"
-  },
-  "settings": {
-    "import/resolver": {
-      "node": {
-        "paths": ["src"],
-        "extensions": [".js", ".jsx"]
-      }
-    }
-  }
+	"env": {
+		"node": true,
+		"browser": true,
+		"es2021": true
+	},
+	"extends": [
+		"eslint:recommended",
+		"plugin:react/recommended",
+		"plugin:import/recommended",
+		"plugin:jsx-a11y/recommended",
+		"plugin:prettier/recommended"
+	],
+	"parserOptions": {
+		"ecmaFeatures": {
+			"jsx": true
+		},
+		"ecmaVersion": "latest",
+		"sourceType": "module"
+	},
+	"plugins": ["prettier"],
+	"rules": {
+		"no-unused-vars": "warn",
+		"react/react-in-jsx-scope": 0,
+		"react/jsx-uses-react": 0,
+		"prettier/prettier": "error",
+		"react/prop-types": "off"
+	},
+	"settings": {
+		"import/resolver": {
+			"node": {
+				"paths": ["src"],
+				"extensions": [".js", ".jsx"]
+			}
+		}
+	}
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,12 @@
       },
       "devDependencies": {
         "eslint": "^8.27.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jsx-a11y": "^6.6.1",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-react": "^7.31.10",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "2.7.1"
       }
     },
@@ -7120,6 +7126,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -7310,6 +7328,27 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7867,6 +7906,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -13886,6 +13931,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -22368,6 +22425,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -22511,6 +22575,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -22829,6 +22902,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -26974,6 +27053,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,12 @@
   },
   "devDependencies": {
     "eslint": "^8.27.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.31.10",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "2.7.1"
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { AppRouter } from './Routes/AppRouter'
+import { AppRouter } from './Routes/AppRouter';
 
 function App() {
 	return <AppRouter />;

--- a/client/src/Components/Common/Btn.jsx
+++ b/client/src/Components/Common/Btn.jsx
@@ -1,1 +1,50 @@
+import styled from 'styled-components';
 
+export const BlackBtn = ({ className, text, callback }) => {
+	return (
+		<BlackBtnStyle onClick={callback} className={className}>
+			{text}
+		</BlackBtnStyle>
+	);
+};
+export const GreenBtn = ({ className, text, callback }) => {
+	return (
+		<GreenBtnStyle onClick={callback} className={className}>
+			{text}
+		</GreenBtnStyle>
+	);
+};
+const BlackBtnStyle = styled.button`
+	padding: 0.5rem 1rem 0.5rem 1rem;
+	border-radius: 22px;
+	font-weight: 500;
+	font-size: 0.85rem;
+	text-align: center;
+	cursor: pointer;
+	background-color: #333333;
+	color: #91f841;
+
+	&:hover {
+		filter: brightness(90%);
+	}
+	&:active {
+		filter: brightness(80%);
+	}
+`;
+const GreenBtnStyle = styled.button`
+	padding: 0.5rem 1rem 0.5rem 1rem;
+	border-radius: 22px;
+	font-weight: 500;
+	font-size: 0.85rem;
+	text-align: center;
+	cursor: pointer;
+	background-color: #91f841;
+	color: #333333;
+
+	&:hover {
+		filter: brightness(90%);
+	}
+	&:active {
+		filter: brightness(80%);
+	}
+`;

--- a/client/src/Components/Common/Header.jsx
+++ b/client/src/Components/Common/Header.jsx
@@ -1,0 +1,5 @@
+import { BlackBtn } from './Btn';
+
+export const Header = () => {
+	return <BlackBtn text="Header" />;
+};

--- a/client/src/Components/Common/Sidebar.jsx
+++ b/client/src/Components/Common/Sidebar.jsx
@@ -1,0 +1,5 @@
+import { GreenBtn } from './Btn';
+
+export const Sidebar = () => {
+	return <GreenBtn text="Sidebar" />;
+};

--- a/client/src/Components/List/List.jsx
+++ b/client/src/Components/List/List.jsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const List = () => {
+	return <div>List</div>;
+};

--- a/client/src/Components/Main/Post.jsx
+++ b/client/src/Components/Main/Post.jsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+import { List } from '../List/List';
+export const Post = () => {
+	return <List />;
+};

--- a/client/src/Pages/Layout.jsx
+++ b/client/src/Pages/Layout.jsx
@@ -1,0 +1,11 @@
+import { Header } from '../Components/Common/Header';
+import { Sidebar } from '../Components/Common/Sidebar';
+const Layout = () => {
+	return (
+		<>
+			<Header />
+			<Sidebar />
+		</>
+	);
+};
+export default Layout;

--- a/client/src/Pages/Loading.jsx
+++ b/client/src/Pages/Loading.jsx
@@ -1,0 +1,4 @@
+const Loading = () => {
+	return <div>Loading...</div>;
+};
+export default Loading;

--- a/client/src/Pages/Main.jsx
+++ b/client/src/Pages/Main.jsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import { List } from '../Components/List/List';
+const Main = () => {
+	return <div>zㅋㅋ</div>;
+};
+export default Main;

--- a/client/src/Pages/Map.jsx
+++ b/client/src/Pages/Map.jsx
@@ -1,9 +1,5 @@
-import React from 'react';
-
 const Map = () => {
-  return 
- 
-  
-}
+	return;
+};
 
 export default Map;

--- a/client/src/Routes/AppRouter.jsx
+++ b/client/src/Routes/AppRouter.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 
+const Loading = lazy(() => import('../Pages/Loading'));
 const Layout = lazy(() => import('../Pages/Layout'));
 const Main = lazy(() => import('../Pages/Main'));
 const Login = lazy(() => import('../Pages/Login'));
@@ -11,14 +12,16 @@ const Map = lazy(() => import('../Pages/Map'));
 export const AppRouter = () => {
 	return (
 		<BrowserRouter>
-			<Suspense>
+			<Suspense fallback={<Loading />}>
 				<Routes>
-					<Route element={<Layout />} />
-					<Route path="/" element={<Main />} />
+					<Route element={<Layout />}>
+						<Route path="/" element={<Main />} />
+						<Route path="/mypage" element={<Mypage />} />
+						<Route path="/detail" element={<Detail />} />
+						<Route path="/map" element={<Map />} />
+					</Route>
 					<Route path="/login" element={<Login />} />
-					<Route path="/map" element={<Map />} />
-					<Route path="/mypage" element={<Mypage />} />
-					<Route path="/detail" element={<Detail />} />
+					<Route path="*" element={<Navigate to="/" replace />} />
 				</Routes>
 			</Suspense>
 		</BrowserRouter>

--- a/client/src/initializer.css
+++ b/client/src/initializer.css
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Poppins:wght@400;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&family=Poppins:wght@400;500;700&display=swap');
 body {
-  margin: 0;
+	margin: 0;
 }
 
 pre,
@@ -90,13 +90,13 @@ time,
 mark,
 audio,
 video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 16px;
-  font-family: "poppins", "Noto Sans KR", -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  vertical-align: baseline;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 16px;
+	font-family: 'poppins', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+		Cantarell, 'Helvetica Neue', sans-serif;
+	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
 article,
@@ -110,30 +110,30 @@ hgroup,
 menu,
 nav,
 section {
-  display: block;
+	display: block;
 }
 body {
-  line-height: 1.5;
+	line-height: 1.5;
 }
 ol,
 ul {
-  list-style: none;
+	list-style: none;
 }
 blockquote,
 q {
-  quotes: none;
+	quotes: none;
 }
 blockquote:before,
 blockquote:after,
 q:before,
 q:after {
-  content: "";
-  content: none;
+	content: '';
+	content: none;
 }
 table {
-  border-collapse: collapse;
-  border-spacing: 0;
+	border-collapse: collapse;
+	border-spacing: 0;
 }
 a {
-  text-decoration: none;
+	text-decoration: none;
 }


### PR DESCRIPTION
1. GreenBtn, BlackBtn 컴포넌트를 추가합니다. 각각의 버튼은 props로 className, text, callback을 받습니다.
2. 라우트 경로를 조정하여 공통 레이아웃이 적용되는 부분과 적용되지 않는 부분을 분리합니다.
3. ESLINT Prettier 플러그인이 오류를 일으키는 현상을 수정합니다. 이 PR이 Merge되면 npm install 하시면 됩니다.
4. 이외 빈 컴포넌트 파일을 추가합니다.