### PR TITLE
FEAT: 라우터 변경, 헤더 및 사이드바, 메인 페이지 골격 작성

### DIFF
--- a/client/src/Components/Common/FollowList.jsx
+++ b/client/src/Components/Common/FollowList.jsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+const FollowList = ({ profileImg, nickname, userId }) => {
+	return (
+		<Link to="">
+			<Conatiner>
+				<Profile />
+				<Id>{nickname}</Id>
+			</Conatiner>
+		</Link>
+	);
+};
+
+const Conatiner = styled.div`
+	padding: 0.5rem 0 0.5rem 0;
+	width: 12rem;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	& :hover {
+		filter: brightness(90%);
+	}
+`;
+const Profile = styled.div`
+	width: 1.75rem;
+	height: 1.75rem;
+	margin-right: 0.5rem;
+	border-radius: 50%;
+	background-image: ${(props) => (props.profileImg === undefined ? 'none' : props.profileImg)};
+	border: ${(props) => (props.profileImg === undefined ? '1px solid #eeeeee' : 'none')};
+`;
+const Id = styled.div`
+	font-size: 0.85rem;
+`;
+
+export default FollowList;

--- a/client/src/Components/Common/Header.jsx
+++ b/client/src/Components/Common/Header.jsx
@@ -1,5 +1,77 @@
-import { BlackBtn } from './Btn';
-
+import styled from 'styled-components';
+import searchIcon from '../../Assets/img/search.svg';
 export const Header = () => {
-	return <BlackBtn text="Header" />;
+	return (
+		<Container>
+			<LeftContainer>
+				<Logo>LOGO</Logo>
+				<SearchForm>
+					<div />
+					<SearchInput placeholder="검색" />
+				</SearchForm>
+			</LeftContainer>
+			<TabContainer>
+				<Tab>TAB</Tab>
+			</TabContainer>
+			<RightContainer>Profile/Menu</RightContainer>
+		</Container>
+	);
 };
+
+const Container = styled.header`
+	display: flex;
+	align-items: center;
+	width: calc (100vw - 1rem);
+	height: 3rem;
+	padding: 0.5rem 1rem 0.5rem 1rem;
+`;
+
+const LeftContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const Logo = styled.div``;
+
+const SearchForm = styled.div`
+	display: flex;
+	align-items: center;
+	border-radius: 20px;
+	margin-left: 1rem;
+	padding: 0 1rem 0 1rem;
+	font-size: 0.9rem;
+	width: 20%;
+	min-width: 10rem;
+	max-width: 25rem;
+	height: 2.5rem;
+	background-color: #eeeeee;
+	div {
+		width: 1.5rem;
+		height: 1.3rem;
+		background-image: url(${searchIcon});
+		background-size: 1.3rem;
+		background-repeat: no-repeat;
+	}
+`;
+
+const SearchInput = styled.input`
+	width: 100%;
+	font-size: 0.9rem;
+	padding: 0 0.5rem 0 0.5rem;
+	height: 2rem;
+	background: none;
+	:focus {
+		outline: none;
+		border-color: #91f841;
+	}
+`;
+
+const TabContainer = styled.nav`
+	display: flex;
+`;
+
+const Tab = styled.div``;
+
+const RightContainer = styled.div`
+	display: flex;
+`;

--- a/client/src/Components/Common/Sidebar.jsx
+++ b/client/src/Components/Common/Sidebar.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import FollowList from './FallowList';
+import FollowList from './FollowList';
 import Tag from './Tag';
 
 const Sidebar = ({ followlist }) => {

--- a/client/src/Components/Common/Sidebar.jsx
+++ b/client/src/Components/Common/Sidebar.jsx
@@ -1,5 +1,49 @@
-import { GreenBtn } from './Btn';
+import styled from 'styled-components';
+import FollowList from './FallowList';
+import Tag from './Tag';
 
-export const Sidebar = () => {
-	return <GreenBtn text="Sidebar" />;
+const Sidebar = ({ followlist }) => {
+	return (
+		<Container>
+			<TagConatiner>
+				<Tag tagName="김재훈" />
+				<Tag tagName="aroowsVd" />
+				<Tag tagName="dev32user" />
+				<Tag tagName="김다혜" />
+				<Tag tagName="seung-yoon-yu" />
+				<Tag tagName="조유종" />
+				<Tag tagName="skynotlimit" />
+			</TagConatiner>
+			<RankContainer>
+				<FollowList nickname="aroowsVd" />
+				<FollowList nickname="dev32user" />
+				<FollowList nickname="김재훈" />
+				<FollowList nickname="김다혜" />
+				<FollowList nickname="seung-yoon-yu" />
+				<FollowList nickname="skynotlimit" />
+				<FollowList nickname="조유종" />
+			</RankContainer>
+			<FollowContainer></FollowContainer>
+		</Container>
+	);
 };
+
+const Container = styled.div`
+	padding: 0 1rem 0 1rem;
+	width: 12rem;
+	height: 100vh;
+`;
+const TagConatiner = styled.div`
+	width: 100%;
+	height: auto;
+`;
+const RankContainer = styled.div`
+	width: 100%;
+	height: auto;
+`;
+const FollowContainer = styled.div`
+	width: 100%;
+	height: auto;
+`;
+
+export default Sidebar;

--- a/client/src/Components/Common/Tag.jsx
+++ b/client/src/Components/Common/Tag.jsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const Tag = ({ className, tagName, callback }) => {
+	return (
+		<TagStyle onClick={callback} className={className}>
+			{tagName}
+		</TagStyle>
+	);
+};
+// 태그 선택 여부(정렬)을 redux로 전역 상태로 올려볼까... 고민임
+const TagStyle = styled.button`
+	padding: 0.25rem 0.75rem 0.25rem 0.75rem;
+	margin: 0 0.25rem 0.25rem 0;
+	border-radius: 22px;
+	font-weight: 500;
+	font-size: 0.7rem;
+	text-align: center;
+	cursor: pointer;
+	border: 1px solid #91f841;
+	background-color: white;
+	color: #333333;
+
+	&:hover {
+		background-color: #91f841;
+	}
+	&:active {
+		filter: brightness(90%);
+	}
+`;
+
+export default Tag;

--- a/client/src/Components/List/List.jsx
+++ b/client/src/Components/List/List.jsx
@@ -1,5 +1,71 @@
 import styled from 'styled-components';
+import { GreenBtn } from '../Common/Btn';
 
-export const List = () => {
-	return <div>List</div>;
+export const List = ({ img, creator, location, profileImg, nickname }) => {
+	return (
+		<Container>
+			<Thumbnail img={img} creator={creator}>
+				<div className="placeholder" />
+				{/* <div className="overlay" /> */}
+				<div className="thumbnailHover">
+					<div className="overlay" />
+					<GreenBtn text="Bookmark" />
+				</div>
+				<img src={img} alt={location} />
+			</Thumbnail>
+			<InfoContainer>
+				<Location location={location}>location</Location>
+				<Nickname nickname={nickname}>
+					<img src={profileImg} alt={nickname} /> nickname
+				</Nickname>
+			</InfoContainer>
+		</Container>
+	);
 };
+
+const Container = styled.div`
+	width: 225px;
+`;
+const Thumbnail = styled.div`
+	position: relative;
+	border-radius: 16px;
+	img {
+		display: ${(props) => (props.img === undefined ? 'none' : 'block')};
+	}
+	.placeholder {
+		border: 1px solid #dddddd;
+		color: #bbbbbb;
+		text-align: center;
+		vertical-align: middle;
+		border-radius: 16px;
+		height: 330px;
+		display: ${(props) => (props.img === undefined ? 'block' : 'none')};
+	}
+	.thumbnailHover {
+		display: none;
+	}
+	:hover {
+		.thumbnailHover {
+			position: absolute;
+			border-radius: 16px;
+			top: 0;
+			left: 0;
+			display: block;
+			width: 225px;
+			height: 330px;
+		}
+		.overlay {
+			position: absolute;
+			border-radius: 16px;
+			top: 0;
+			left: 0;
+			background-color: black;
+			opacity: 0.5;
+			width: 100%;
+			height: 100%;
+		}
+	}
+`;
+const InfoContainer = styled.div``;
+const Location = styled.div``;
+const Nickname = styled.div``;

--- a/client/src/Pages/LayoutH.jsx
+++ b/client/src/Pages/LayoutH.jsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+import { Header } from '../Components/Common/Header';
+import Sidebar from '../Components/Common/Sidebar';
+const Layout = () => {
+	return (
+		<>
+			<Header />
+			<Outlet />
+		</>
+	);
+};
+export default Layout;

--- a/client/src/Pages/LayoutHS.jsx
+++ b/client/src/Pages/LayoutHS.jsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import styled from 'styled-components';
+import { Header } from '../Components/Common/Header';
+import Sidebar from '../Components/Common/Sidebar';
+const Layout = () => {
+	return (
+		<>
+			<Header />
+			<Body>
+				<Sidebar />
+				<Outlet />
+			</Body>
+		</>
+	);
+};
+
+const Body = styled.div`
+	display: flex;
+`;
+
+export default Layout;

--- a/client/src/Pages/Main.jsx
+++ b/client/src/Pages/Main.jsx
@@ -1,6 +1,19 @@
 import styled from 'styled-components';
 import { List } from '../Components/List/List';
 const Main = () => {
-	return <div>zㅋㅋ</div>;
+	return (
+		<>
+			<Container>
+				<List />
+				<List />
+				<List />
+				<List />
+				<List />
+			</Container>
+		</>
+	);
 };
+const Container = styled.div`
+	display: flex;
+`;
 export default Main;

--- a/client/src/Routes/AppRouter.jsx
+++ b/client/src/Routes/AppRouter.jsx
@@ -2,7 +2,8 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 
 const Loading = lazy(() => import('../Pages/Loading'));
-const Layout = lazy(() => import('../Pages/Layout'));
+const LayoutHS = lazy(() => import('../Pages/LayoutHS'));
+const LayoutH = lazy(() => import('../Pages/LayoutH'));
 const Main = lazy(() => import('../Pages/Main'));
 const Login = lazy(() => import('../Pages/Login'));
 const Signup = lazy(() => import('../Pages/Signup'));
@@ -16,15 +17,17 @@ export const AppRouter = () => {
 		<BrowserRouter>
 			<Suspense fallback={<Loading />}>
 				<Routes>
-					<Route element={<Layout />}>
+					<Route element={<LayoutHS />}>
 						<Route path="/" element={<Main />} />
 						<Route path="/mypage" element={<Mypage />} />
 						<Route path="/edit" element={<Edit />} />
 						<Route path="/detail" element={<Detail />} />
 						<Route path="/map" element={<Map />} />
 					</Route>
-					<Route path="/login" element={<Login />} />
-					<Route path="/signup" element={<Signup />} />
+					<Route element={<LayoutH />}>
+						<Route path="/login" element={<Login />} />
+						<Route path="/signup" element={<Signup />} />
+					</Route>
 					<Route path="*" element={<Navigate to="/" replace />} />
 				</Routes>
 			</Suspense>


### PR DESCRIPTION
1. 레이아웃 파일을 헤더만 있는 경우와 헤더와 사이드바 모두 있는 경우로 세분화합니다. 이에 따라 라우터도 수정합니다.
2. 헤더 및 사이드바, 메인 페이지의 골격을 작성했습니다. 이제 만들고 계신 모든 페이지에 헤더나 사이드바가 나옵니다.
3. 공통 컴포넌트에 태그가 추가되었습니다. 태그는 기본적으로 버튼입니다.