### PR TITLE
[FIX] RefreshTokenRepository 대조하여 인증하도록 일괄 변경, Post.gpsY 필드 삭제

### DIFF
--- a/server/src/main/java/com/example/seb_main_project/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/com/example/seb_main_project/bookmark/controller/BookmarkController.java
@@ -4,6 +4,7 @@ import com.example.seb_main_project.bookmark.dto.BookmarkDto;
 import com.example.seb_main_project.bookmark.entity.Bookmark;
 import com.example.seb_main_project.bookmark.mapper.BookmarkMapper;
 import com.example.seb_main_project.bookmark.service.BookmarkService;
+import com.example.seb_main_project.member.service.MemberService;
 import com.example.seb_main_project.post.mapper.PostMapper;
 import com.example.seb_main_project.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +24,15 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
     private final PostService postService;
+    private final MemberService memberService;
     private final BookmarkMapper bookmarkMapper;
     private final PostMapper postMapper;
 
     @PostMapping("/main/{post-id}/bookmark")
     public void createBookmark(
             @PathVariable("post-id") Integer postId,
-            @CookieValue(name = "memberId") Integer memberId) {
+            @RequestHeader("Authorization") String authorization) {
+        Integer memberId = memberService.getTokenMember(authorization);
         bookmarkService.addBookmark(postId, memberId);
     }
 
@@ -39,7 +42,9 @@ public class BookmarkController {
     @GetMapping("/post/{post-id}/bookmark")
     public ResponseEntity<BookmarkDto.ExistBookmarkResponseDto> checkBookmark(
             @PathVariable("post-id") Integer postId,
-            @CookieValue(name = "memberId") Integer memberId) {
+            @RequestHeader("Authorization") String authorization) {
+        Integer memberId = memberService.getTokenMember(authorization);
+
         return new ResponseEntity<>(
                 bookmarkMapper.booleanToBookmarkResponseDto(
                         bookmarkService.checkBookmark(postId, memberId)), HttpStatus.OK);

--- a/server/src/main/java/com/example/seb_main_project/comment/controller/CommentController.java
+++ b/server/src/main/java/com/example/seb_main_project/comment/controller/CommentController.java
@@ -38,7 +38,7 @@ public class CommentController {
             @RequestParam int size,
             @PathVariable("post-id") Integer postId) {
 
-        Page<Comment> pageComments = commentService.findPageComments(postId,page - 1, size);
+        Page<Comment> pageComments = commentService.findPageComments(postId, page - 1, size);
         List<Comment> findComments = pageComments.getContent();
 
         return new ResponseEntity<>(
@@ -61,8 +61,8 @@ public class CommentController {
     public ResponseEntity postComment(
             @PathVariable("post-id") Integer postId,
             @RequestBody CommentDto.CommentPostDto commentPostDto,
-            @CookieValue(name = "memberId") Integer memberId) {
-
+            @RequestHeader("Authorization") String authorization) {
+        Integer memberId = memberService.getTokenMember(authorization);
         Comment comment = commentService.createComment(commentPostDto, postId, memberId);
 
         return new ResponseEntity<>(commentMapper.commentToCommentResponseDto(comment), HttpStatus.CREATED);
@@ -70,11 +70,12 @@ public class CommentController {
 
     @PutMapping("/main/{post-id}/{comment-id}/edit")
     public ResponseEntity updateComment(
-            @CookieValue(name = "memberId") Integer memberId,
+            @RequestHeader("Authorization") String authorization,
             @PathVariable("comment-id") Integer commentId,
             @RequestBody CommentDto.CommentPatchDto commentPatchDto,
             @PathVariable("post-id") String parameter) {
 
+        Integer memberId = memberService.getTokenMember(authorization);
         Comment updatedComment = commentService.updateComment(memberId, commentId, commentPatchDto);
 
         return new ResponseEntity<>(commentMapper.commentToCommentResponseDto(updatedComment), HttpStatus.OK);
@@ -82,10 +83,11 @@ public class CommentController {
 
     @DeleteMapping("/main/{post-id}/{comment-id}/delete")
     public ResponseEntity deleteComment(
-            @CookieValue(name = "memberId") Integer memberId,
+            @RequestHeader("Authorization") String authorization,
             @PathVariable("comment-id") Integer commentId,
             @PathVariable("post-id") String parameter) {
 
+        Integer memberId = memberService.getTokenMember(authorization);
         commentService.deleteComment(memberId, commentId);
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/server/src/main/java/com/example/seb_main_project/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/seb_main_project/member/controller/MemberController.java
@@ -42,7 +42,8 @@ public class MemberController {
     @PutMapping("/member-info/edit")
     public ResponseEntity updateMember(
             @RequestBody AuthDto.Update updateDto,
-            @CookieValue(name = "memberId") Integer memberId) {
+            @RequestHeader("Authorization") String authorization) {
+        Integer memberId = memberService.getTokenMember(authorization);
         Member member = memberService.updateMember(updateDto, memberId);
         return new ResponseEntity<>(memberMapper.memberToMemberResponseDto(member), HttpStatus.OK);
     }

--- a/server/src/main/java/com/example/seb_main_project/member/service/DBMemberService.java
+++ b/server/src/main/java/com/example/seb_main_project/member/service/DBMemberService.java
@@ -5,6 +5,7 @@ import com.example.seb_main_project.exception.ExceptionCode;
 import com.example.seb_main_project.member.dto.AuthDto;
 import com.example.seb_main_project.member.entity.Member;
 import com.example.seb_main_project.member.repository.MemberRepository;
+import com.example.seb_main_project.security.repository.RefreshTokenRepository;
 import com.example.seb_main_project.security.utils.CustomAuthorityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ public class DBMemberService implements MemberService {
     private final PasswordEncoder passwordEncoder;
     private final CustomAuthorityUtils customAuthorityUtils;
 
+    private final RefreshTokenRepository refreshTokenRepository;
 
     /**
      * Member 회원가입 DB 저장 메서드
@@ -72,4 +74,16 @@ public class DBMemberService implements MemberService {
                     throw new BusinessLogicException(ExceptionCode.MEMBER_EXISTS);
                 });
     }
+
+    /**
+     * refreshToken 존재 여부 확인 후 해당 토큰의 memberId 반환
+     */
+    @Override
+    public Integer getTokenMember(String authorization) {
+        return refreshTokenRepository.findRefreshTokenByTokenValue(
+                        authorization.substring(7))
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.TOKEN_NOT_FOUND))
+                .getMemberId();
+    }
+
 }

--- a/server/src/main/java/com/example/seb_main_project/member/service/MemberService.java
+++ b/server/src/main/java/com/example/seb_main_project/member/service/MemberService.java
@@ -9,4 +9,6 @@ public interface MemberService {
     Boolean checkNickname(String nickname);
 
     Member updateMember(AuthDto.Update updateDto, Integer memberId);
+
+    Integer getTokenMember(String authorization);
 }

--- a/server/src/main/java/com/example/seb_main_project/post/dto/PostDto.java
+++ b/server/src/main/java/com/example/seb_main_project/post/dto/PostDto.java
@@ -10,7 +10,6 @@ public class PostDto {
     @Getter
     public static class PostCreateDto {
         private String gpsX;
-        private String gpsY;
         private String contents;
     }
 
@@ -21,7 +20,6 @@ public class PostDto {
     @ToString
     public static class PostPatchDto {
         private String gpsX;
-        private String gpsY;
         private String contents;
 
         private Integer postId;
@@ -38,7 +36,6 @@ public class PostDto {
         private String contents;
         private Integer likeCount;
         private String gpsX;
-        private String gpsY;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
     }

--- a/server/src/main/java/com/example/seb_main_project/post/entity/Post.java
+++ b/server/src/main/java/com/example/seb_main_project/post/entity/Post.java
@@ -34,9 +34,6 @@ public class Post extends Auditable {
     private String gpsX;
 
     @Column
-    private String gpsY;
-
-    @Column
     private String tags;
 
     @Column

--- a/server/src/main/java/com/example/seb_main_project/post/service/PostService.java
+++ b/server/src/main/java/com/example/seb_main_project/post/service/PostService.java
@@ -57,7 +57,6 @@ public class PostService {
 
         Post createdPost = Post.builder()
                 .gpsX(post.getGpsX())
-                .gpsY(post.getGpsY())
                 .contents(post.getContents())
                 .member(member)
                 .nickname(member.getNickname())

--- a/server/src/main/java/com/example/seb_main_project/security/jwt/JwtTokenizer.java
+++ b/server/src/main/java/com/example/seb_main_project/security/jwt/JwtTokenizer.java
@@ -14,6 +14,7 @@ import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -35,6 +36,7 @@ import static com.example.seb_main_project.security.utils.JwtConstants.REFRESH_T
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtTokenizer {
 
     @Getter
@@ -182,7 +184,9 @@ public class JwtTokenizer {
      */
     public String isExistRefresh(Cookie[] cookies) {
         for (Cookie cookie : cookies) {
-            if (cookie.getName().equals(REFRESH_TOKEN)) return cookie.getValue();
+            if (cookie.getName().equals(REFRESH_TOKEN)) {
+                log.info(String.valueOf(cookie));
+                return cookie.getValue();};
         }
         throw new BusinessLogicException(ExceptionCode.COOKIE_NOT_FOUND);
     }


### PR DESCRIPTION
프론트 팀원 요청으로 gpsY 필드 삭제

클라이언트와 연결 문제가 있었던 쿠키로 memberId 받는 방식 대신, refreshToken 레포지토리와 대조하여 인증하도록 일괄 변경